### PR TITLE
feat: expose the served url in the respective apis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -435,7 +435,7 @@ export async function runExperiment(document, options, context) {
   // Fullpage content experiment
   document.body.classList.add(`experiment-${experimentConfig.id}`);
   const result = await replaceInner(pages[index], document.querySelector('main'));
-  experimentConfig.servedUrl = result ? pages[index] : window.location.pathname;
+  experimentConfig.servedExperience = result ? pages[index] : currentPath;
   if (!result) {
     // eslint-disable-next-line no-console
     console.debug(`failed to serve variant ${window.hlx.experiment.selectedVariant}. Falling back to ${experimentConfig.variantNames[0]}.`);
@@ -487,7 +487,7 @@ export async function runCampaign(document, options, context) {
   try {
     const url = new URL(urlString);
     const result = replaceInner(url.pathname, document.querySelector('main'));
-    window.hlx.campaign.servedUrl = result ? url.pathname : window.location.pathname;
+    window.hlx.campaign.servedExperience = result ? url.pathname : window.location.pathname;
     if (!result) {
       // eslint-disable-next-line no-console
       console.debug(`failed to serve campaign ${campaign}. Falling back to default content.`);
@@ -541,7 +541,7 @@ export async function serveAudience(document, options, context) {
   try {
     const url = new URL(urlString);
     const result = replaceInner(url.pathname, document.querySelector('main'));
-    window.hlx.audience.servedUrl = result ? url.pathname : window.location.pathname;
+    window.hlx.audience.servedExperience = result ? url.pathname : window.location.pathname;
     if (!result) {
       // eslint-disable-next-line no-console
       console.debug(`failed to serve audience ${selectedAudience}. Falling back to default content.`);

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ export async function getResolvedAudiences(applicableAudiences, options, context
  * Replaces element with content from path
  * @param {string} path
  * @param {HTMLElement} element
- * @param {boolean} isBlock
+ * @return Returns the path that was loaded or null if the loading failed
  */
 async function replaceInner(path, element) {
   const plainPath = path.endsWith('/')
@@ -92,12 +92,12 @@ async function replaceInner(path, element) {
     const html = await resp.text();
     // eslint-disable-next-line no-param-reassign
     element.innerHTML = html;
-    return true;
+    return plainPath;
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(`error loading content: ${plainPath}`, e);
   }
-  return false;
+  return null;
 }
 
 /**
@@ -435,7 +435,7 @@ export async function runExperiment(document, options, context) {
   // Fullpage content experiment
   document.body.classList.add(`experiment-${experimentConfig.id}`);
   const result = await replaceInner(pages[index], document.querySelector('main'));
-  experimentConfig.servedExperience = result ? pages[index] : currentPath;
+  experimentConfig.servedExperience = result || currentPath;
   if (!result) {
     // eslint-disable-next-line no-console
     console.debug(`failed to serve variant ${window.hlx.experiment.selectedVariant}. Falling back to ${experimentConfig.variantNames[0]}.`);
@@ -487,7 +487,7 @@ export async function runCampaign(document, options, context) {
   try {
     const url = new URL(urlString);
     const result = replaceInner(url.pathname, document.querySelector('main'));
-    window.hlx.campaign.servedExperience = result ? url.pathname : window.location.pathname;
+    window.hlx.campaign.servedExperience = result || window.location.pathname;
     if (!result) {
       // eslint-disable-next-line no-console
       console.debug(`failed to serve campaign ${campaign}. Falling back to default content.`);
@@ -541,7 +541,7 @@ export async function serveAudience(document, options, context) {
   try {
     const url = new URL(urlString);
     const result = replaceInner(url.pathname, document.querySelector('main'));
-    window.hlx.audience.servedExperience = result ? url.pathname : window.location.pathname;
+    window.hlx.audience.servedExperience = result || window.location.pathname;
     if (!result) {
       // eslint-disable-next-line no-console
       console.debug(`failed to serve audience ${selectedAudience}. Falling back to default content.`);

--- a/src/index.js
+++ b/src/index.js
@@ -435,6 +435,7 @@ export async function runExperiment(document, options, context) {
   // Fullpage content experiment
   document.body.classList.add(`experiment-${experimentConfig.id}`);
   const result = await replaceInner(pages[index], document.querySelector('main'));
+  experimentConfig.servedUrl = result ? pages[index] : window.location.pathname;
   if (!result) {
     // eslint-disable-next-line no-console
     console.debug(`failed to serve variant ${window.hlx.experiment.selectedVariant}. Falling back to ${experimentConfig.variantNames[0]}.`);
@@ -481,9 +482,12 @@ export async function runCampaign(document, options, context) {
     return false;
   }
 
+  window.hlx.campaign = { selectedCampaign: campaign };
+
   try {
     const url = new URL(urlString);
     const result = replaceInner(url.pathname, document.querySelector('main'));
+    window.hlx.campaign.servedUrl = result ? url.pathname : window.location.pathname;
     if (!result) {
       // eslint-disable-next-line no-console
       console.debug(`failed to serve campaign ${campaign}. Falling back to default content.`);
@@ -526,17 +530,21 @@ export async function serveAudience(document, options, context) {
     ? context.toClassName(usp.get(pluginOptions.audiencesQueryParameter))
     : null;
 
-  const urlString = configuredAudiences[forcedAudience || audiences[0]];
+  const selectedAudience = forcedAudience || audiences[0];
+  const urlString = configuredAudiences[selectedAudience];
   if (!urlString) {
     return false;
   }
 
+  window.hlx.audience = { selectedAudience };
+
   try {
     const url = new URL(urlString);
     const result = replaceInner(url.pathname, document.querySelector('main'));
+    window.hlx.audience.servedUrl = result ? url.pathname : window.location.pathname;
     if (!result) {
       // eslint-disable-next-line no-console
-      console.debug(`failed to serve audience ${forcedAudience || audiences[0]}. Falling back to default content.`);
+      console.debug(`failed to serve audience ${selectedAudience}. Falling back to default content.`);
     }
     document.body.classList.add(audiences.map((audience) => `audience-${audience}`));
     context.sampleRUM('audiences', {


### PR DESCRIPTION
The PR exposes the final url that is served in the API, so it can be picked up if needed by analytics tooling.

Supersedes #6 

## API

### Experiments
`window.hlx.experiment.servedExperience`

### Campaigns
`window.hlx.campaign.selectedCampaign`
`window.hlx.campaign.servedExperience`

### Audiences
`window.hlx.audience.selectedAudience`
`window.hlx.audience.servedExperience`

Co-authored-by: ilievlad73 <ilievlad73@gmail.com>