### PR TITLE
feat: update plugin to leverage v3 RUM APIs and domain key

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,13 @@ You have already seen the `audiences` option in the examples above, but here is 
 runEager.call(pluginContext, {
   // Overrides the base path if the plugin was installed in a sub-directory
   basePath: '',
-  // Lets you configure if we are in a prod environment or not
+
+  // Lets you configure the prod environment.
   // (prod environments do not get the pill overlay)
+  prodHost: 'https://my-website.com',
+  // if you have several, or need more complex logic to toggle pill overlay, you can use
   isProd: () => window.location.hostname.endsWith('hlx.page')
-    || window.location.hostname === ('localhost')
+    || window.location.hostname === ('localhost'),
 
   /* Generic properties */
   // RUM sampling rate on regular AEM pages is 1 out of 100 page views

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ runEager.call(pluginContext, {
 
   // Lets you configure the prod environment.
   // (prod environments do not get the pill overlay)
-  prodHost: 'https://my-website.com',
+  prodHost: 'www.my-website.com',
   // if you have several, or need more complex logic to toggle pill overlay, you can use
   isProd: () => window.location.hostname.endsWith('hlx.page')
     || window.location.hostname === ('localhost'),

--- a/src/index.js
+++ b/src/index.js
@@ -676,7 +676,8 @@ export async function loadLazy(document, options, context) {
   };
   if (window.location.hostname.endsWith('hlx.page')
     || window.location.hostname === ('localhost')
-    || (typeof options.isProd === 'function' && !options.isProd())) {
+    || (typeof options.isProd === 'function' && !options.isProd())
+    || (options.prodHost && options.prodHost !== window.location.origin)) {
     // eslint-disable-next-line import/no-cycle
     const preview = await import('./preview.js');
     preview.default(document, pluginOptions, { ...context, getResolvedAudiences });

--- a/src/preview.css
+++ b/src/preview.css
@@ -112,6 +112,7 @@
   background-color: #222;
   border-radius: 16px 16px 0 0;
   padding: 24px 16px;
+  gap: 0 16px;
 }
 
 .hlx-popup-header-label {
@@ -188,6 +189,7 @@
   margin: 16px;
   padding: 16px;
   border-radius: 16px;
+  gap: 0 16px;
 }
 
 .hlx-popup-item-label {
@@ -217,5 +219,5 @@
   .hlx-preview-overlay {
     flex-flow: row-reverse wrap-reverse;
     justify-content: flex-start;
-  }  
+  }
 }

--- a/src/preview.js
+++ b/src/preview.js
@@ -27,7 +27,9 @@ function createButton(label) {
 
 function createPopupItem(item) {
   const actions = typeof item === 'object'
-    ? item.actions.map((action) => `<div class="hlx-button"><a href="${action.href}">${action.label}</a></div>`)
+    ? item.actions.map((action) => (action.href
+      ? `<div class="hlx-button"><a href="${action.href}">${action.label}</a></div>`
+      : `<div class="hlx-button"><a href="#">${action.label}</a></div>`))
     : [];
   const div = document.createElement('div');
   div.className = `hlx-popup-item${item.isSelected ? ' is-selected' : ''}`;
@@ -35,12 +37,20 @@ function createPopupItem(item) {
     <h5 class="hlx-popup-item-label">${typeof item === 'object' ? item.label : item}</h5>
     ${item.description ? `<div class="hlx-popup-item-description">${item.description}</div>` : ''}
     ${actions.length ? `<div class="hlx-popup-item-actions">${actions}</div>` : ''}`;
+  const buttons = [...div.querySelectorAll('.hlx-button a')];
+  item.actions.forEach((action, index) => {
+    if (action.onclick) {
+      buttons[index].addEventListener('click', action.onclick);
+    }
+  });
   return div;
 }
 
 function createPopupDialog(header, items = []) {
   const actions = typeof header === 'object'
-    ? (header.actions || []).map((action) => `<div class="hlx-button"><a href="${action.href}">${action.label}</a></div>`)
+    ? (header.actions || []).map((action) => (action.href
+      ? `<div class="hlx-button"><a href="${action.href}">${action.label}</a></div>`
+      : `<div class="hlx-button"><a href="#">${action.label}</a></div>`))
     : [];
   const popup = document.createElement('div');
   popup.className = 'hlx-popup hlx-hidden';
@@ -54,6 +64,12 @@ function createPopupDialog(header, items = []) {
   const list = popup.querySelector('.hlx-popup-items');
   items.forEach((item) => {
     list.append(createPopupItem(item));
+  });
+  const buttons = [...popup.querySelectorAll('.hlx-popup-header-actions .hlx-button a')];
+  header.actions.forEach((action, index) => {
+    if (action.onclick) {
+      buttons[index].addEventListener('click', action.onclick);
+    }
   });
   return popup;
 }
@@ -144,12 +160,26 @@ function createVariant(experiment, variantName, config, options) {
 }
 
 async function fetchRumData(experiment, options) {
+  if (!options.domainKey) {
+    // eslint-disable-next-line no-console
+    console.warn('Cannot show RUM data. No `domainKey` configured.');
+    return null;
+  }
+  if (!options.prodHost && (typeof options.isProd !== 'function' || !options.isProd())) {
+    // eslint-disable-next-line no-console
+    console.warn('Cannot show RUM data. No `prodHost` configured or custom `isProd` method provided.');
+    return null;
+  }
+
   // the query is a bit slow, so I'm only fetching the results when the popup is opened
-  const resultsURL = new URL('https://helix-pages.anywhere.run/helix-services/run-query@v2/rum-experiments');
+  const resultsURL = new URL('https://helix-pages.anywhere.run/helix-services/run-query@v3/rum-experiments');
   resultsURL.searchParams.set(options.experimentsQueryParameter, experiment);
-  if (window.hlx.sidekickConfig && window.hlx.sidekickConfig.host) {
-    // restrict results to the production host, this also reduces query cost
-    resultsURL.searchParams.set('domain', window.hlx.sidekickConfig.host);
+  resultsURL.searchParams.set('domainKey', options.domainKey);
+  // restrict results to the production host, this also reduces query cost
+  if (typeof options.isProd === 'function' && options.isProd()) {
+    resultsURL.searchParams.set('domain', window.location.origin);
+  } else if (options.prodHost) {
+    resultsURL.searchParams.set('domain', options.prodHost);
   }
 
   const response = await fetch(resultsURL.href);
@@ -185,7 +215,7 @@ async function fetchRumData(experiment, options) {
     const vkey = k.replace(/^(variant|control)_/, 'variant_');
     const ckey = k.replace(/^(variant|control)_/, 'control_');
     const tkey = k.replace(/^(variant|control)_/, 'total_');
-    if (o[ckey] && o[vkey]) {
+    if (!Number.isNaN(o[ckey]) && !Number.isNaN(o[vkey])) {
       o[tkey] = o[ckey] + o[vkey];
     }
     return o;
@@ -282,6 +312,7 @@ async function decorateExperimentPill(overlay, options, context) {
   // eslint-disable-next-line no-console
   console.log('preview experiment', experiment);
 
+  const domainKey = window.localStorage.getItem('franklin-domainkey');
   const pill = createPopupButton(
     `Experiment: ${config.id}`,
     {
@@ -296,7 +327,32 @@ async function decorateExperimentPill(overlay, options, context) {
           ${config.variants[config.variantNames[0]].blocks.join(',')}
         </div>
         <div class="hlx-info">How is it going?</div>`,
-      actions: config.manifest ? [{ label: 'Manifest', href: config.manifest }] : [],
+      actions: [
+        ...config.manifest ? [{ label: 'Manifest', href: config.manifest }] : [],
+        {
+          label: '<span style="font-size:2em;line-height:1em">⚙</span>',
+          onclick: async () => {
+            // eslint-disable-next-line no-alert
+            const key = window.prompt(
+              'Please enter your domain key:',
+              window.localStorage.getItem('franklin-domainkey') || '',
+            );
+            if (key && key.match(/[a-f0-9-]+/)) {
+              window.localStorage.setItem('franklin-domainkey', key);
+              const performanceMetrics = await fetchRumData(experiment, {
+                ...options,
+                domainKey: key,
+              });
+              if (performanceMetrics === null) {
+                return;
+              }
+              populatePerformanceMetrics(pill, config, performanceMetrics);
+            } else if (key === '') {
+              window.localStorage.removeItem('franklin-domainkey');
+            }
+          },
+        },
+      ],
     },
     config.variantNames.map((vname) => createVariant(experiment, vname, config, options)),
   );
@@ -305,7 +361,7 @@ async function decorateExperimentPill(overlay, options, context) {
   }
   overlay.append(pill);
 
-  const performanceMetrics = await fetchRumData(experiment, options);
+  const performanceMetrics = await fetchRumData(experiment, { ...options, domainKey });
   if (performanceMetrics === null) {
     return;
   }

--- a/src/preview.js
+++ b/src/preview.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+const DOMAIN_KEY_NAME = 'aem-domainkey';
+
 function createPreviewOverlay(cls) {
   const overlay = document.createElement('div');
   overlay.className = cls;
@@ -177,7 +179,7 @@ async function fetchRumData(experiment, options) {
   resultsURL.searchParams.set('domainKey', options.domainKey);
   // restrict results to the production host, this also reduces query cost
   if (typeof options.isProd === 'function' && options.isProd()) {
-    resultsURL.searchParams.set('domain', window.location.origin);
+    resultsURL.searchParams.set('domain', window.location.host);
   } else if (options.prodHost) {
     resultsURL.searchParams.set('domain', options.prodHost);
   }
@@ -312,7 +314,7 @@ async function decorateExperimentPill(overlay, options, context) {
   // eslint-disable-next-line no-console
   console.log('preview experiment', experiment);
 
-  const domainKey = window.localStorage.getItem('franklin-domainkey');
+  const domainKey = window.localStorage.getItem(DOMAIN_KEY_NAME);
   const pill = createPopupButton(
     `Experiment: ${config.id}`,
     {
@@ -335,10 +337,10 @@ async function decorateExperimentPill(overlay, options, context) {
             // eslint-disable-next-line no-alert
             const key = window.prompt(
               'Please enter your domain key:',
-              window.localStorage.getItem('franklin-domainkey') || '',
+              window.localStorage.getItem(DOMAIN_KEY_NAME) || '',
             );
             if (key && key.match(/[a-f0-9-]+/)) {
-              window.localStorage.setItem('franklin-domainkey', key);
+              window.localStorage.setItem(DOMAIN_KEY_NAME, key);
               const performanceMetrics = await fetchRumData(experiment, {
                 ...options,
                 domainKey: key,
@@ -348,7 +350,7 @@ async function decorateExperimentPill(overlay, options, context) {
               }
               populatePerformanceMetrics(pill, config, performanceMetrics);
             } else if (key === '') {
-              window.localStorage.removeItem('franklin-domainkey');
+              window.localStorage.removeItem(DOMAIN_KEY_NAME);
             }
           },
         },


### PR DESCRIPTION
Updates the pill overlay to leverage the RUM v3 APIs now that the v2 ones were taken down.

## Description

We replace the API call with the newer v3 endpoint, and also introduce a dialog to let the author specify the domain key to use to pull the data since the API is now protected.

- Add a new `prodHost` config so customer can specify the host to use to capture the RUM data
- Add dialog to specify the domain key to be used for RUM data retrieval, and save it in the local storage under `aem-domainkey`
- Fix `NaN` error with some data values
- Add warning messages if domain key or prod host are not specified
- Update documentation