### PR TITLE
fix: invalid url when given a path for variant

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,7 @@ function getConfigForInstantExperiment(
     variantNames: [],
   };
 
-  const pages = instantExperiment.split(',').map((p) => new URL(p.trim()).pathname);
+  const pages = instantExperiment.split(',').map((p) => new URL(p.trim(), window.location).pathname);
 
   const splitString = context.getMetadata(`${pluginOptions.experimentsMetaTag}-split`);
   const splits = splitString


### PR DESCRIPTION
If the author or content source sets a path only we have to provide a base URL to construct a new URL.

This is the default for AEM Authoring with Edge Delivery Services as we will maintain the variants meta data as path and not as absolute URL.
