### PR TITLE
fix: lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-src/ued.js

--- a/src/index.js
+++ b/src/index.js
@@ -682,15 +682,18 @@ function adjustedRumSamplingRate(checkpoint, options, context) {
 function adjustRumSampligRate(document, options, context) {
   const checkpoints = ['audiences', 'campaign', 'experiment'];
   if (context.sampleRUM.always) { // RUM v1.x
-    checkpoints.forEach((ck) => context.sampleRUM.always.on(ck, adjustedRumSamplingRate(ck, options, context)));
+    checkpoints.forEach((ck) => {
+      context.sampleRUM.always.on(ck, adjustedRumSamplingRate(ck, options, context));
+    });
   } else { // RUM 2.x
     document.addEventListener('rum', (event) => {
-      if (event.detail && event.detail.checkpoint && checkpoints.includes(event.detail.checkpoint)) {
+      if (event.detail
+        && event.detail.checkpoint
+        && checkpoints.includes(event.detail.checkpoint)) {
         adjustedRumSamplingRate(event.detail.checkpoint, options, context);
       }
     });
   }
-
 }
 
 export async function loadEager(document, options, context) {
@@ -713,9 +716,9 @@ export async function loadLazy(document, options, context) {
   if (window.location.hostname.endsWith('.live')
     || (typeof options.isProd === 'function' && options.isProd())
     || (options.prodHost
-        && (options.prodHost === window.location.host
-          || options.prodHost === window.location.hostname
-          || options.prodHost === window.location.origin))) {
+      && (options.prodHost === window.location.host
+        || options.prodHost === window.location.hostname
+        || options.prodHost === window.location.origin))) {
     return;
   }
   // eslint-disable-next-line import/no-cycle

--- a/src/ued.js
+++ b/src/ued.js
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+/* eslint-disable */
 
 var storage = window.sessionStorage;
 


### PR DESCRIPTION
There are some linting errors when adding experimentation to a boilerplate project:

https://github.com/adobe-rnd/aem-boilerplate-xwalk/actions/runs/9174200125/job/25224528750?pr=22

This is caused by some fixable errors in `index.js` but also by the `ued.js`. This file is listed in `.eslintignore`. That works here but not in a project as `.eslintignore` must be in the project root: https://eslint.org/docs/latest/use/configure/ignore-deprecated#the-eslintignore-file. Adding a `/* eslint-disable */` to the file helps.