### PR TITLE
fix: update getAllMetadata function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,11 +94,17 @@ export function getMetadata(name) {
  */
 export function getAllMetadata(scope) {
   const value = getMetadata(scope);
-  return [...document.head.querySelectorAll(`meta[name^="${scope}-"]`)]
-    .reduce((res, meta) => {
-      const key = toCamelCase(meta.name.substring(scope.length + 1));
-      res[key] = meta.getAttribute('content');
-      return res;
+  const metaTags = document.head.querySelectorAll(`meta[name^="${scope}-"], meta[property^="${scope}:-"]`);
+
+  return [...metaTags].reduce((res, meta) => {
+    const key = meta.getAttribute('name')
+      ? meta.getAttribute('name').substring(scope.length + 1)
+      : meta.getAttribute('property').substring(scope.length + 2);
+
+    const camelCaseKey = toCamelCase(key);
+    res[camelCaseKey] = meta.getAttribute('content');
+    
+    return res;
     }, value ? { value } : {});
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -103,9 +103,8 @@ export function getAllMetadata(scope) {
 
     const camelCaseKey = toCamelCase(key);
     res[camelCaseKey] = meta.getAttribute('content');
-    
     return res;
-    }, value ? { value } : {});
+  }, value ? { value } : {});
 }
 
 /**

--- a/tests/fixtures/audiences/page-level.html
+++ b/tests/fixtures/audiences/page-level.html
@@ -1,7 +1,7 @@
 <html>
 <head>
-  <meta name="audience-foo" content="/tests/fixtures/audiences/variant-1"/>
-  <meta name="audience-bar" content="/tests/fixtures/audiences/variant-2"/>
+  <meta property="audience-foo" content="/tests/fixtures/audiences/variant-1"/>
+  <meta property="audience-bar" content="/tests/fixtures/audiences/variant-2"/>
   <script>
     window.AUDIENCES = {
       foo: () => true,

--- a/tests/fixtures/audiences/page-level.html
+++ b/tests/fixtures/audiences/page-level.html
@@ -1,7 +1,8 @@
 <html>
 <head>
-  <meta property="audience:-foo" content="/tests/fixtures/audiences/variant-1"/>
-  <meta property="audience:-bar" content="/tests/fixtures/audiences/variant-2"/>
+  <meta name="audience-foo" content="/tests/fixtures/audiences/variant-1"/>
+  <meta name="audience-bar" content="/tests/fixtures/audiences/variant-2"/>
+  <meta property="audience:-baz" content="/tests/fixtures/audiences/variant-1"/>
   <script>
     window.AUDIENCES = {
       foo: () => true,

--- a/tests/fixtures/audiences/page-level.html
+++ b/tests/fixtures/audiences/page-level.html
@@ -2,7 +2,7 @@
 <head>
   <meta name="audience-foo" content="/tests/fixtures/audiences/variant-1"/>
   <meta name="audience-bar" content="/tests/fixtures/audiences/variant-2"/>
-  <meta property="audience:-baz" content="/tests/fixtures/audiences/variant-1"/>
+  <meta property="audience:-foo" content="/tests/fixtures/audiences/variant-1"/>
   <script>
     window.AUDIENCES = {
       foo: () => true,

--- a/tests/fixtures/audiences/page-level.html
+++ b/tests/fixtures/audiences/page-level.html
@@ -1,7 +1,7 @@
 <html>
 <head>
-  <meta property="audience-foo" content="/tests/fixtures/audiences/variant-1"/>
-  <meta property="audience-bar" content="/tests/fixtures/audiences/variant-2"/>
+  <meta property="audience:-foo" content="/tests/fixtures/audiences/variant-1"/>
+  <meta property="audience:-bar" content="/tests/fixtures/audiences/variant-2"/>
   <script>
     window.AUDIENCES = {
       foo: () => true,

--- a/tests/fixtures/experiments/page-level--audiences.html
+++ b/tests/fixtures/experiments/page-level--audiences.html
@@ -3,8 +3,6 @@
   <meta name="experiment" content="foo"/>
   <meta name="experiment-variants" content="/tests/fixtures/experiments/page-level-v1,/tests/fixtures/experiments/page-level-v2"/>
   <meta name="experiment-audiences" content="bar"/>
-  <meta property="audience:-v1" content="/tests/fixtures/experiments/page-level-v1"/>
-  <meta property="audience:-v2" content="/tests/fixtures/experiments/page-level-v2"/>
   <script type="module" src="/tests/fixtures/scripts.js"></script>
 </head>
 <body>

--- a/tests/fixtures/experiments/page-level--audiences.html
+++ b/tests/fixtures/experiments/page-level--audiences.html
@@ -3,6 +3,8 @@
   <meta name="experiment" content="foo"/>
   <meta name="experiment-variants" content="/tests/fixtures/experiments/page-level-v1,/tests/fixtures/experiments/page-level-v2"/>
   <meta name="experiment-audiences" content="bar"/>
+  <meta property="audience:-v1" content="/tests/fixtures/experiments/page-level-v1"/>
+  <meta property="audience:-v2" content="/tests/fixtures/experiments/page-level-v2"/>
   <script type="module" src="/tests/fixtures/scripts.js"></script>
 </head>
 <body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the getMetadata function in extracting metadata tags from the document's head. The function now is able to handle meta tags with names or properties. (e.g. < meta property="campaign:-registration" content="https://main--wknd--hlxsites.hlx.page/drafts/xfeng/page-variants/page-variant1" >)

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
