### PR TITLE
feat: support customized variant name for fragment variants

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -584,7 +584,7 @@ async function getExperimentConfig(pluginOptions, metadata, overrides) {
   };
 
   // get the custom labels for the variants names
-  const labelNames = stringToArray(metadata.names);
+  const labelNames = stringToArray(metadata.variant ?? metadata.names);
   pages.forEach((page, i) => {
     const vname = `challenger-${i + 1}`;
     //  label with custom name or default

--- a/src/index.js
+++ b/src/index.js
@@ -584,7 +584,7 @@ async function getExperimentConfig(pluginOptions, metadata, overrides) {
   };
 
   // get the custom labels for the variants names
-  const labelNames = stringToArray(metadata.variant ?? metadata.names);
+  const labelNames = stringToArray(metadata.name);
   pages.forEach((page, i) => {
     const vname = `challenger-${i + 1}`;
     //  label with custom name or default
@@ -659,9 +659,9 @@ async function getExperimentConfig(pluginOptions, metadata, overrides) {
  */
 function parseExperimentManifest(entries) {
   return Object.values(Object.groupBy(
-    entries.map((e) => depluralizeProps(e, ['experiment', 'variant', 'split'])),
+    entries.map((e) => depluralizeProps(e, ['experiment', 'name', 'split'])),
     ({ experiment }) => experiment,
-  )).map(aggregateEntries('experiment', ['split', 'url', 'variant']));
+  )).map(aggregateEntries('experiment', ['split', 'url', 'name']));
 }
 
 function getUrlFromExperimentConfig(config) {

--- a/src/index.js
+++ b/src/index.js
@@ -610,7 +610,7 @@ async function getExperimentConfig(pluginOptions, metadata, overrides) {
 
   const config = {
     id,
-    label: metadata.name || `Experiment ${metadata.value || metadata.experiment}`,
+    label: `Experiment ${metadata.value || metadata.experiment}`,
     status: metadata.status || 'active',
     audiences,
     endDate,

--- a/src/index.js
+++ b/src/index.js
@@ -659,9 +659,9 @@ async function getExperimentConfig(pluginOptions, metadata, overrides) {
  */
 function parseExperimentManifest(entries) {
   return Object.values(Object.groupBy(
-    entries.map((e) => depluralizeProps(e, ['experiment', 'name', 'split'])),
+    entries.map((e) => depluralizeProps(e, ['experiment', 'variant', 'split', 'name'])),
     ({ experiment }) => experiment,
-  )).map(aggregateEntries('experiment', ['split', 'url', 'name']));
+  )).map(aggregateEntries('experiment', ['split', 'url', 'variant', 'name']));
 }
 
 function getUrlFromExperimentConfig(config) {

--- a/src/index.js
+++ b/src/index.js
@@ -785,7 +785,7 @@ async function runCampaign(document, pluginOptions) {
       const { selectedCampaign = 'default' } = config;
       const campaign = result ? toClassName(selectedCampaign) : 'default';
       el.dataset.audience = selectedCampaign;
-      el.dataset.audiences = pluginOptions.audiences.join(',');
+      el.dataset.audiences = Object.keys(pluginOptions.audiences).join(',');
       el.classList.add(`campaign-${campaign}`);
       window.hlx?.rum?.sampleRUM('audiences', {
         source: `campaign-${campaign}`,
@@ -856,7 +856,7 @@ function getUrlFromAudienceConfig(config) {
 }
 
 async function serveAudience(document, pluginOptions) {
-  document.body.dataset.audiences = pluginOptions.audiences.join(',');
+  document.body.dataset.audiences = Object.keys(pluginOptions.audiences).join(',');
   return applyAllModifications(
     pluginOptions.audiencesMetaTagPrefix,
     pluginOptions.audiencesQueryParameter,
@@ -871,7 +871,7 @@ async function serveAudience(document, pluginOptions) {
       el.classList.add(`audience-${audience}`);
       window.hlx?.rum?.sampleRUM('audiences', {
         source: audience,
-        target: pluginOptions.audiences.join(':'),
+        target: Object.keys(pluginOptions.audiences).join(':'),
       });
       document.dispatchEvent(new CustomEvent('aem:experimentation', {
         detail: {

--- a/tests/experiments.test.js
+++ b/tests/experiments.test.js
@@ -287,7 +287,7 @@ test.describe('Fragment-level experiments', () => {
             'challenger-1': expect.objectContaining({ percentageSplit: '0.3333' }),
             'challenger-2': expect.objectContaining({ percentageSplit: '0.3333' }),
           },
-          label: expect.arrayContaining([expect.stringMatching(/Control|C1|C2/)]),
+          label: expect.stringMatching(/Experiment Baz/),
         }),
         servedExperience: expect.stringMatching(/\/tests\/fixtures\/experiments\/(fragment|section)-level/),
       }),

--- a/tests/experiments.test.js
+++ b/tests/experiments.test.js
@@ -287,6 +287,7 @@ test.describe('Fragment-level experiments', () => {
             'challenger-1': expect.objectContaining({ percentageSplit: '0.3333' }),
             'challenger-2': expect.objectContaining({ percentageSplit: '0.3333' }),
           },
+          label: expect.stringMatching(/Control|C1|C2/),
         }),
         servedExperience: expect.stringMatching(/\/tests\/fixtures\/experiments\/(fragment|section)-level/),
       }),

--- a/tests/experiments.test.js
+++ b/tests/experiments.test.js
@@ -287,7 +287,7 @@ test.describe('Fragment-level experiments', () => {
             'challenger-1': expect.objectContaining({ percentageSplit: '0.3333' }),
             'challenger-2': expect.objectContaining({ percentageSplit: '0.3333' }),
           },
-          label: expect.stringMatching(/Control|C1|C2/),
+          label: expect.arrayContaining([expect.stringMatching(/Control|C1|C2/)]),
         }),
         servedExperience: expect.stringMatching(/\/tests\/fixtures\/experiments\/(fragment|section)-level/),
       }),

--- a/tests/fixtures/experiments/fragment-level--async.html
+++ b/tests/fixtures/experiments/fragment-level--async.html
@@ -11,7 +11,7 @@
     window.setTimeout(() => {
       const div = document.createElement('div');
       div.classList.add('fragment');
-      div.textContent = 'Hello v1!';
+      div.textContent = 'Hello World!';
       document.body.querySelector('main>div').append(div);
     });
   </script>

--- a/tests/fixtures/experiments/fragment-level--async.html
+++ b/tests/fixtures/experiments/fragment-level--async.html
@@ -11,7 +11,7 @@
     window.setTimeout(() => {
       const div = document.createElement('div');
       div.classList.add('fragment');
-      div.textContent = 'Hello World!';
+      div.textContent = 'Hello v1!';
       document.body.querySelector('main>div').append(div);
     });
   </script>

--- a/tests/fixtures/experiments/fragments--alt.json
+++ b/tests/fixtures/experiments/fragments--alt.json
@@ -4,6 +4,7 @@
           "Pages": "/tests/fixtures/experiments/fragment-level--alt",
           "Experiments": "Baz",
           "Variants": "challenger-1",
+          "Names": "C1",
           "Selectors": ".fragment",
           "Urls": "/tests/fixtures/experiments/section-level-v1"
       },
@@ -11,6 +12,7 @@
           "Pages": "/tests/fixtures/experiments/fragment-level--alt",
           "Experiments": "Baz",
           "Variants": "challenger-2",
+          "Names": "C2",
           "Selectors": ".fragment",
           "Urls": "/tests/fixtures/experiments/section-level-v2"
       }

--- a/tests/fixtures/experiments/fragments.json
+++ b/tests/fixtures/experiments/fragments.json
@@ -4,6 +4,7 @@
           "Page": "/tests/fixtures/experiments/fragment-level",
           "Experiment": "Baz",
           "Variant": "challenger-1",
+          "Names": "C1",
           "Selector": ".fragment",
           "Url": "/tests/fixtures/experiments/section-level-v1"
       },
@@ -11,6 +12,7 @@
           "Page": "/tests/fixtures/experiments/fragment-level",
           "Experiment": "Baz",
           "Variant": "challenger-2",
+          "Names": "C2",
           "Selector": ".fragment",
           "Url": "/tests/fixtures/experiments/section-level-v2"
       },
@@ -18,6 +20,7 @@
           "Page": "/tests/fixtures/experiments/fragment-level--async",
           "Experiment": "Baz",
           "Variant": "challenger-1",
+          "Names": "C1",
           "Selector": ".fragment",
           "Url": "/tests/fixtures/experiments/section-level-v1"
       },
@@ -25,6 +28,7 @@
           "Page": "/tests/fixtures/experiments/fragment-level--async",
           "Experiment": "Baz",
           "Variant": "challenger-2",
+          "Names": "C2",
           "Selector": ".fragment",
           "Url": "/tests/fixtures/experiments/section-level-v2"
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Leverage"Variant" entry in manifest to support variant name customization for fragment experimentation. 

<!--- Describe your changes in detail -->
![Untitled (1)](https://github.com/user-attachments/assets/74c8f053-c2c9-4c3d-9009-558b0e98e4ad)
## Related Issue


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
