### PR TITLE
feat: Add decoration handler for handling fragment decoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You have already seen the `audiences` option in the examples above, but here is 
 
 ```js
 runEager.call(document, {
-  // Let you configure the prod environment.
+  // Lets you configure the prod environment.
   // (prod environments do not get the pill overlay)
   prodHost: 'www.my-website.com',
   // if you have several, or need more complex logic to toggle pill overlay, you can use
@@ -185,7 +185,7 @@ For detailed implementation instructions on the different features, please read 
 - [Experiments](/documentation/experiments.md)
 
 **Cases of passing `decorationFunction`**
-Fragment replacement is handled by async observer, which may execute before or after default decoration complete. Therefore, the project needs to provide a decoration method. There are several common cases:
+Fragment replacement is handled by async observer, which may execute before or after default decoration complete. So, you need to provide a decoration method to redecorate. There are several common cases:
 1. Have a selector for an element inside a block and the block needs to be redecorated => sample code above
 2. Have a `.block` selector and  need to redecorate => switch block status to `"loading"` and call `loadBlock(el)`
 3. Have a `.section` selector and need to redecorate => call `decorateBlocks(el)`

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You have already seen the `audiences` option in the examples above, but here is 
 
 ```js
 runEager.call(document, {
-  // Lets you configure the prod environment.
+  // Let you configure the prod environment.
   // (prod environments do not get the pill overlay)
   prodHost: 'www.my-website.com',
   // if you have several, or need more complex logic to toggle pill overlay, you can use
@@ -168,6 +168,14 @@ runEager.call(document, {
   // See more details on the dedicated Experiments page linked below
   experimentsMetaTagPrefix: 'experiment',
   experimentsQueryParameter: 'experiment',
+
+  /* Fragment experiment needs redecoration */
+  // See more details below
+  decorationFunction: (el) => {
+    /* handle custom decoration here, for example: */
+    buildBlock(el);
+    decorateBlock(el);
+  }
 });
 ```
 
@@ -175,6 +183,13 @@ For detailed implementation instructions on the different features, please read 
 - [Audiences](/documentation/audiences.md)
 - [Campaigns](/documentation/campaigns.md)
 - [Experiments](/documentation/experiments.md)
+
+**Cases of passing `decorationFunction`**
+Fragment replacement is handled by async observer, which may execute before or after default decoration complete. Therefore, the project needs to provide a decoration method. There are several common cases:
+1. Have a selector for an element inside a block and the block needs to be redecorated => sample code above
+2. Have a `.block` selector and  need to redecorate => switch block status to `"loading"` and call `loadBlock(el)`
+3. Have a `.section` selector and need to redecorate => call `decorateBlocks(el)`
+4. Have a `main` selector and need to redecorate => call `decorateMain(el)`
 
 ## Extensibility & integrations
 

--- a/src/index.js
+++ b/src/index.js
@@ -439,7 +439,7 @@ function watchMutationsAndApplyFragments(
       if (url && new URL(url, window.location.origin).pathname !== window.location.pathname) {
         // eslint-disable-next-line no-await-in-loop
         res = await replaceInner(new URL(url, window.location.origin).pathname, el, entry.selector);
-        pluginOptions.decorateFunction(el);
+        await pluginOptions.decorateFunction(el);
       } else {
         res = url;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -439,6 +439,7 @@ function watchMutationsAndApplyFragments(
       if (url && new URL(url, window.location.origin).pathname !== window.location.pathname) {
         // eslint-disable-next-line no-await-in-loop
         res = await replaceInner(new URL(url, window.location.origin).pathname, el, entry.selector);
+        // eslint-disable-next-line no-await-in-loop
         await pluginOptions.decorateFunction(el);
       } else {
         res = url;

--- a/src/index.js
+++ b/src/index.js
@@ -905,9 +905,9 @@ export async function loadEager(document, options = {}) {
   setDebugMode(window.location, pluginOptions);
 
   const ns = window.aem || window.hlx || {};
-  ns.audiences = await serveAudience.call(this, document, pluginOptions);
-  ns.experiments = await runExperiment.call(this, document, pluginOptions);
-  ns.campaigns = await runCampaign.call(this, document, pluginOptions);
+  ns.audiences = await serveAudience(document, pluginOptions);
+  ns.experiments = await runExperiment(document, pluginOptions);
+  ns.campaigns = await runCampaign(document, pluginOptions);
 
   // Backward compatibility
   ns.experiment = ns.experiments.find((e) => e.type === 'page');

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,9 @@ export const DEFAULT_OPTIONS = {
   // Experimentation related properties
   experimentsMetaTagPrefix: 'experiment',
   experimentsQueryParameter: 'experiment',
+
+  // Redecoration function for fragments
+  decorateFunction: () => {},
 };
 
 /**
@@ -85,46 +88,6 @@ export function toCamelCase(name) {
 export function removeLeadingHyphens(inputString) {
   // Remove all leading hyphens which are converted from the space in metadata
   return inputString.replace(/^(-+)/, '');
-}
-
-/**
- * Check if the block is a hero block and rebuild it if needed.
- * @param {Function} buildBlock
- * @param {Element} el
- * @returns revised element
- */
-function rebuildIfHeroBlock(buildBlock, element) {
-  if (!element.classList.contains('hero')) return element;
-  const main = element.parentElement.parentElement;
-  [...element.children].reverse().forEach((el) => main.prepend(el));
-  element.remove();
-
-  // build hero block
-  const h1 = main.querySelector('main > div > h1');
-  const picture = main.querySelector('main > div > p > picture');
-  // eslint-disable-next-line no-bitwise
-  if (h1 && picture && (h1.compareDocumentPosition(picture) & Node.DOCUMENT_POSITION_PRECEDING)) {
-    const section = document.createElement('div');
-    section.append(buildBlock('hero', { elems: [picture, h1] }));
-    main.prepend(section);
-  }
-
-  return document.querySelector('.hero');
-}
-
-/**
- * Check if the reDecorateBlocks() and buildBlock() are defined.
- * @param {Function} buildBlock
- * @param {Function} reDecorateBlocks
- * @returns boolean
- */
-function isRedecorateValid(buildBlock, reDecorateBlocks) {
-  if (typeof reDecorateBlocks === 'function' && typeof buildBlock === 'function') {
-    return true;
-  }
-  // eslint-disable-next-line no-console
-  console.warn('reDecorateBlocks() or buildBlock() is not defined.');
-  return false;
 }
 
 /**
@@ -476,6 +439,7 @@ function watchMutationsAndApplyFragments(
       if (url && new URL(url, window.location.origin).pathname !== window.location.pathname) {
         // eslint-disable-next-line no-await-in-loop
         res = await replaceInner(new URL(url, window.location.origin).pathname, el, entry.selector);
+        pluginOptions.decorateFunction(el);
       } else {
         res = url;
       }
@@ -749,9 +713,6 @@ async function runExperiment(document, pluginOptions) {
           variant,
         },
       }));
-      if (variant !== 'control' && isRedecorateValid(this.buildBlock, this.reDecorateBlocks)) {
-        this.reDecorateBlocks(rebuildIfHeroBlock(this.buildBlock, el));
-      }
     },
   );
 }
@@ -853,9 +814,6 @@ async function runCampaign(document, pluginOptions) {
           campaign,
         },
       }));
-      if (campaign !== 'default' && isRedecorateValid(this.buildBlock, this.reDecorateBlocks)) {
-        this.reDecorateBlocks(rebuildIfHeroBlock(this.buildBlock, el));
-      }
     },
   );
 }
@@ -938,9 +896,6 @@ async function serveAudience(document, pluginOptions) {
           audience,
         },
       }));
-      if (audience !== 'default' && isRedecorateValid(this.buildBlock, this.reDecorateBlocks)) {
-        this.reDecorateBlocks(rebuildIfHeroBlock(this.buildBlock, el));
-      }
     },
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The fragment decoration needs more logic on handling decorations. 
We leveraged Eventlistener, at the same time introduce decoration handler on index.js to handle the logic of redecorating. 

<!--- Describe your changes in detail -->
`reDecorateBlocks` function and `buildBlock` fucntion are defined inside of project's script.js, where we need to pass from.
```
export function reDecorateBlocks(el) {
  if (!el.classList.contains('block')) return;
  decorateBlock(el);
  loadBlock(el);
}
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
