### PR TITLE
Update: Extract customized names from 'Experiment Variant Name(s)' in page metadata

### DIFF
--- a/documentation/experiments.md
+++ b/documentation/experiments.md
@@ -83,7 +83,7 @@ To customize the labels, add a new entry in the page metadata or section metadat
 |---------------------|--------------------------------------------------------------|
 | Experiment          | Hero Test                                                    |
 | Experiment Variants | [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-1](), [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-2](), [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-3]() |
-| Experiment Names    |  foo1, foo2, foo3                                                 |
+| Experiment Variant Names    |  foo1, foo2, foo3                                                 |
 
 The names defined will match with the corresponding variants in sequence. If the number of names provided is less than the number of variants, the default naming will be applied for the remaining variants.
 

--- a/src/index.js
+++ b/src/index.js
@@ -600,8 +600,11 @@ async function getExperimentConfig(pluginOptions, metadata, overrides) {
     label: 'Control',
   };
 
-  // get the custom labels for the variants names
-  const labelNames = stringToArray(metadata.name);
+  // get the customized name for the variant in page metadata and manifest
+  const labelNames = stringToArray(metadata.name)?.length
+    ? stringToArray(metadata.name)
+    : stringToArray(depluralizeProps(metadata, ['variantName']).variantName);
+
   pages.forEach((page, i) => {
     const vname = `challenger-${i + 1}`;
     //  label with custom name or default


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In the demo, we agree that defining `Experiment Name` property for customizing variant name is not intuitive enough and can confuse with `Experiment` property. 
Therefore, I update the doc to `Experiment Variant Name` or `Experiment Variant Names` , that authors can define the variant name and also leverage the experimentsMetaTagPrefix. 
<img width="400" alt="Screenshot 2024-08-06 at 9 23 40 AM" src="https://github.com/user-attachments/assets/7ebb66f5-2977-45f2-a470-916928b4f2cc">



<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
