### PR TITLE
feat: Support page level full redirection

### DIFF
--- a/documentation/audiences.md
+++ b/documentation/audiences.md
@@ -70,6 +70,16 @@ The audiences are set up directly in the page metadata block as follows:
 
 The notation is pretty flexible and authors can also use `Audience (Mobile)` or `Audience Mobile` if this is a preferred notation.
 
+#### Page redirect
+
+If you aim to direct your audience to a target URL instead of just replacing the content, you can do so by adding the `Audience Resolution | redirect` property to the page metadata:
+
+| Metadata            |                                                               |
+|---------------------|---------------------------------------------------------------|
+| Audience: Mobile    | [https://{ref}--{repo}--{org}.hlx.page/my-page-for-mobile]()  |
+| Audience: Desktop   | [https://{ref}--{repo}--{org}.hlx.page/my-page-for-desktop]() |
+| Audience Resolution | redirect                                                      |
+
 ### Section-level audiences
 
 Each section in a page can also run any number of audiences. Section-level audiences are run after the page-level audiences have run, i.e. after the variants have been processed and their markup was pulled into the main page, so the section-level audiences that will run are dictated by the document from the current page-level experiment/audience/campaign, and not necessarily just the main page.

--- a/documentation/campaigns.md
+++ b/documentation/campaigns.md
@@ -57,6 +57,16 @@ If you wanted to additionally restrict the campaign to specific audiences, so th
 If any of the listed audiences is resolved, then the campaign will run and the matching content will be served.
 If you needed both audiences to be resolved, you'd define a new `mobile-iphone` audience in your project and use that in the metadata instead.
 
+#### Page Redirect
+
+If you aim to fully direct a campaign page to a target URL instead of just replacing the content, you can do so by adding the `Campaign Resolution | redirect` property to the page metadata:
+
+| Metadata             |                                                                 |
+|----------------------|-----------------------------------------------------------------|
+| Campaign: Xmas       | [https://{ref}--{repo}--{org}.hlx.page/my-page-for-xmas]()      |
+| Campaign: Halloween  | [https://{ref}--{repo}--{org}.hlx.page/my-page-for-halloween]() |
+| Campaign Resolution  | redirect                                                        |
+
 ### Section-level audiences
 
 Each section in a page can also run any number of campaigns. Section-level campaigns are run after the page-level campaigns have run, i.e. after the variants have been processed and their markup was pulled into the main page, so the section-level campaigns that will run are dictated by the document from the current page-level experiment/audience/campaign, and not necessarily just the main page.

--- a/documentation/experiments.md
+++ b/documentation/experiments.md
@@ -128,6 +128,17 @@ Start and end dates are in the flexible JS [Date Time String Format](https://tc3
 
 So you can both use generic dates, like `2024-01-31` or `2024/01/31`, and time-specific dates like `2024-01-31T13:37` or `2024/01/31 1:37 pm`. You can even enforce a specific timezone so your experiment activates when, say, it's 2am GMT+1 by using `2024/1/31 2:00 pm GMT+1` or similar notations.
 
+#### Full redirects
+For the use case that fully redirect to the target URL instead of just replacing the content, you could add a new property `Experiment Resolution | redirect` in page metadata:
+| Metadata              |                                                              |
+|-----------------------|--------------------------------------------------------------|
+| Experiment            | Hero Test                                                    |
+| Experiment Variants   | [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-1](), [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-2](), [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-3]() |
+| Experiment Resolution     | redirect
+
+Same for the audience and campaign personalization, by adding the following property to redirect to target URL:
+`Audience Resolution: redirect`
+`Campaign Resolution: redirect`
 ### Section-level experiments
 
 Each section in a page can also run 1 experiment, so you can have as many section-level experiments as you have sections.

--- a/documentation/experiments.md
+++ b/documentation/experiments.md
@@ -128,17 +128,23 @@ Start and end dates are in the flexible JS [Date Time String Format](https://tc3
 
 So you can both use generic dates, like `2024-01-31` or `2024/01/31`, and time-specific dates like `2024-01-31T13:37` or `2024/01/31 1:37 pm`. You can even enforce a specific timezone so your experiment activates when, say, it's 2am GMT+1 by using `2024/1/31 2:00 pm GMT+1` or similar notations.
 
-#### Full redirects
-For the use case that fully redirect to the target URL instead of just replacing the content, you could add a new property `Experiment Resolution | redirect` in page metadata:
+#### Redirect page experiments
+For the use case that fully redirect to the target URL instead of just replacing the content (our default behavior), you could add a new property `Experiment Resolution | redirect` in page metadata:
 | Metadata              |                                                              |
 |-----------------------|--------------------------------------------------------------|
 | Experiment            | Hero Test                                                    |
 | Experiment Variants   | [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-1](), [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-2](), [https://{ref}--{repo}--{org}.hlx.page/my-page-variant-3]() |
 | Experiment Resolution     | redirect
 
-Same for the audience and campaign personalization, by adding the following property to redirect to target URL:
-`Audience Resolution: redirect`
-`Campaign Resolution: redirect`
+In this example, the Hero Test experiment will redirect to one of the specified URLs when you simulate that variant.
+
+Similarly, the redirects for audience personalization and campaign personalization could be enabled by adding:
+
+`Audience Resolution | redirect`
+`Campaign Resolution | redirect`
+
+For more details, refer to: [audiences](./audiences.md#page-redirect), [campaigns](./campaigns.md#page-redirect)
+
 ### Section-level experiments
 
 Each section in a page can also run 1 experiment, so you can have as many section-level experiments as you have sections.

--- a/src/index.js
+++ b/src/index.js
@@ -373,13 +373,14 @@ function createModificationsHandler(
     const url = await getExperienceUrl(ns.config);
     let res;
     if (url && new URL(url, window.location.origin).pathname !== window.location.pathname) {
-      if (metadata?.resolution === 'redirect') {
+      if (toClassName(metadata?.resolution) === 'redirect') {
+        // Firing RUM event early since redirection will stop the rest of the JS execution
         fireRUM(type, config, pluginOptions, url);
         window.location.replace(url);
-      } else {
-        // eslint-disable-next-line no-await-in-loop
-        res = await replaceInner(new URL(url, window.location.origin).pathname, el);
+        return null;
       }
+      // eslint-disable-next-line no-await-in-loop
+      res = await replaceInner(new URL(url, window.location.origin).pathname, el);
     } else {
       res = url;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,33 @@ export function toClassName(name) {
 }
 
 /**
+ * Fires a Real User Monitoring (RUM) event based on the provided type and configuration.
+ * @param {string} type - the type of event to be fired ("experiment", "campaign", or "audience")
+ * @param {Object} config - contains details about the experience
+ * @param {Object} pluginOptions - default plugin options with custom options
+ * @param {string} result - the URL of the served experience.
+ */
+function fireRUM(type, config, pluginOptions, result) {
+  const sampleData = {
+    experiment: {
+      source: config.id,
+      target: result ? config.selectedVariant : config.variantNames[0],
+    },
+    campaign: {
+      source: result ? toClassName(config.selectedCampaign) : 'default',
+      target: Object.keys(pluginOptions.audiences).join(':'),
+    },
+    audience: {
+      source: result ? toClassName(config.selectedAudience) : 'default',
+      target: Object.keys(pluginOptions.audiences).join(':'),
+    },
+  };
+
+  const rumType = type === 'experiment' ? 'experiment' : 'audience';
+  window.hlx?.rum?.sampleRUM(rumType, sampleData[type]);
+}
+
+/**
  * Sanitizes a name for use as a js property name.
  * @param {String} name The unsanitized name
  * @returns {String} The camelCased name
@@ -321,6 +348,7 @@ function toDecisionPolicy(config) {
  * Creates an instance of a modification handler that will be responsible for applying the desired
  * personalized experience.
  *
+ * @param {String} type The type of modifications to apply
  * @param {Object} overrides The config overrides
  * @param {Function} metadataToConfig a function that will handle the parsing of the metadata
  * @param {Function} getExperienceUrl a function that returns the URL to the experience
@@ -329,6 +357,7 @@ function toDecisionPolicy(config) {
  * @returns the modification handler
  */
 function createModificationsHandler(
+  type,
   overrides,
   metadataToConfig,
   getExperienceUrl,
@@ -344,8 +373,13 @@ function createModificationsHandler(
     const url = await getExperienceUrl(ns.config);
     let res;
     if (url && new URL(url, window.location.origin).pathname !== window.location.pathname) {
-      // eslint-disable-next-line no-await-in-loop
-      res = await replaceInner(new URL(url, window.location.origin).pathname, el);
+      if (metadata?.resolution === 'redirect') {
+        fireRUM(type, config, pluginOptions, url);
+        window.location.replace(url);
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        res = await replaceInner(new URL(url, window.location.origin).pathname, el);
+      }
     } else {
       res = url;
     }
@@ -479,6 +513,7 @@ async function applyAllModifications(
   cb,
 ) {
   const modificationsHandler = createModificationsHandler(
+    type,
     getAllQueryParameters(paramNS),
     metadataToConfig,
     getExperienceUrl,
@@ -699,16 +734,14 @@ async function runExperiment(document, pluginOptions) {
     parseExperimentManifest,
     getUrlFromExperimentConfig,
     (el, config, result) => {
+      fireRUM('experiment', config, pluginOptions, result);
+      // dispatch event
       const { id, selectedVariant, variantNames } = config;
       const variant = result ? selectedVariant : variantNames[0];
       el.dataset.experiment = id;
       el.dataset.variant = variant;
       el.classList.add(`experiment-${toClassName(id)}`);
       el.classList.add(`variant-${toClassName(variant)}`);
-      window.hlx?.rum?.sampleRUM('experiment', {
-        source: id,
-        target: variant,
-      });
       document.dispatchEvent(new CustomEvent('aem:experimentation', {
         detail: {
           element: el,
@@ -802,15 +835,13 @@ async function runCampaign(document, pluginOptions) {
     parseCampaignManifest,
     getUrlFromCampaignConfig,
     (el, config, result) => {
+      fireRUM('campaign', config, pluginOptions, result);
+      // dispatch event
       const { selectedCampaign = 'default' } = config;
       const campaign = result ? toClassName(selectedCampaign) : 'default';
       el.dataset.audience = selectedCampaign;
       el.dataset.audiences = Object.keys(pluginOptions.audiences).join(',');
       el.classList.add(`campaign-${campaign}`);
-      window.hlx?.rum?.sampleRUM('audience', {
-        source: campaign,
-        target: Object.keys(pluginOptions.audiences).join(':'),
-      });
       document.dispatchEvent(new CustomEvent('aem:experimentation', {
         detail: {
           element: el,
@@ -885,14 +916,12 @@ async function serveAudience(document, pluginOptions) {
     parseAudienceManifest,
     getUrlFromAudienceConfig,
     (el, config, result) => {
+      fireRUM('audience', config, pluginOptions, result);
+      // dispatch event
       const { selectedAudience = 'default' } = config;
       const audience = result ? toClassName(selectedAudience) : 'default';
       el.dataset.audience = audience;
       el.classList.add(`audience-${audience}`);
-      window.hlx?.rum?.sampleRUM('audience', {
-        source: audience,
-        target: Object.keys(pluginOptions.audiences).join(':'),
-      });
       document.dispatchEvent(new CustomEvent('aem:experimentation', {
         detail: {
           element: el,

--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,8 @@ function createModificationsHandler(
         // Firing RUM event early since redirection will stop the rest of the JS execution
         fireRUM(type, config, pluginOptions, url);
         window.location.replace(url);
-        return null;
+        // eslint-disable-next-line consistent-return
+        return;
       }
       // eslint-disable-next-line no-await-in-loop
       res = await replaceInner(new URL(url, window.location.origin).pathname, el);

--- a/src/index.js
+++ b/src/index.js
@@ -378,7 +378,7 @@ function createModificationsHandler(
         fireRUM(type, config, pluginOptions, url);
         window.location.replace(url);
         // eslint-disable-next-line consistent-return
-        return;
+        return ns;
       }
       // eslint-disable-next-line no-await-in-loop
       res = await replaceInner(new URL(url, window.location.origin).pathname, el);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The aim is to run full-page experimentation and personalization use cases that fully redirect to the target URL instead of just replacing the content for a marketer.

The new properties are introduced:
```
Experiment Resolution | redirect
Audience Resolution   | redirect
Campaign Resolution   | redirect
```
<img width="624" alt="Screenshot 2024-08-13 at 7 44 24 AM" src="https://github.com/user-attachments/assets/60794d53-78f7-411e-9276-f6da3f165c7f">

   
When simulate the variant, rather than 'replace' the page, url is redirected by calling `window.location.replace(url)` API 

<img width="600" alt="Screenshot 2024-08-13 at 7 45 59 AM" src="https://github.com/user-attachments/assets/eefb3c7d-72ac-4a93-9c7b-45a9aa982c88">



## How Has This Been Tested?

**Test link:**
- [wknd page](https://experimentation-v2-integration--wknd--hlxsites.hlx.page/drafts/xfeng/experiments/page)
- [wknd doc](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B316CD824-E05C-452D-92DD-506039911607%7D&file=page.docx&action=default&mobileredirect=true)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
